### PR TITLE
Print zero FlagValue as empty string

### DIFF
--- a/flag/util.go
+++ b/flag/util.go
@@ -32,6 +32,10 @@ func (v *FlagValue) Error() error {
 }
 
 func (v *FlagValue) String() string {
+	if v.collector == nil {
+		return ""
+	}
+	
 	return toString(v.Config(), v.collector.GetOptions(), v.onError)
 }
 


### PR DESCRIPTION
Changes FlagValue.String() to handle the zero value case.

The zero value is converted to an empty string to distinguish it from the empty JSON object.

This is a go 1.7 compatibility fix to address the changes in https://github.com/golang/go/commit/3659645cb1f32d7b1eeefdb65f1339fe54f0f6eb

A related issue is: https://github.com/golang/go/issues/16694
